### PR TITLE
Error on exports file

### DIFF
--- a/templates/etc/exports
+++ b/templates/etc/exports
@@ -1,5 +1,5 @@
 # {{ ansible_managed }}
 
 {%  for export in nfs_server_exports %}
-  {{ export.path }} {{ export.source }}{{ export.permissions }};
+{{ export.path }} {{ export.source }}{{ export.permissions }}
 {%  endfor %}


### PR DESCRIPTION
The exports file have a bad syntax : Exporting directories for NFS kernel daemon...exportfs: /etc/exports:2: syntax error: bad option list

Removing space and the semicolon make it works
